### PR TITLE
Add homepage search and split Frontend Development sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 - [Revue: fears and risks](#revue-fears-and-risks)
 - [GDPR](#gdpr)
 - [Frontend Development](#frontend-development)
+    - [Articles & Tutorials](#articles--tutorials)
+    - [HTML Email Templates](#html-email-templates)
 - [Github Repositories](#github-repositories)
 - [Checkers](#checkers)
 - [GitHub repositories related to email marketing](#github-repositories-related-to-email-marketing)
@@ -360,30 +362,38 @@ Order is :
 
 ### Frontend Development
 
-- [Responsive Email Templates](https://zurb.com/playground/responsive-email-templates)
-- [The Most Common Email Coding Mistakes and How to Avoid Them](https://sendpulse.com/blog/email-coding-mistakes)
-- [How to Code a Responsive Email from Scratch](https://litmus.com/community/learning/24-how-to-code-a-responsive-email-from-scratch)
-- [HTML Email Development Best Practices: Rules to Code By](https://www.emailonacid.com/blog/article/email-development/email-development-best-practices-2/)
-- [How To Code An Email Newsletter in 6 Simple Steps](https://www.crazyegg.com/blog/how-to-code-an-email-newsletter/)
+Resources for building HTML emails — tutorials stay separate from template collections. Docs: [`website/docs/development/`](./website/docs/development/).
+
+#### Articles & Tutorials
+
 - [HTML Email Basics](https://templates.mailchimp.com/getting-started/html-email-basics/)
-- [A Complete Guide To HTML Email](https://www.smashingmagazine.com/2021/04/complete-guide-html-email-templates-tools/)
-- [Coding html emails](https://www.campaignmonitor.com/dev-resources/guides/coding-html-emails/)
 - [New to email coding? Here’s where to start](https://explore.reallygoodemails.com/new-to-email-coding-heres-where-to-start-2494422f0bd4)
+- [How To Code An Email Newsletter in 6 Simple Steps](https://www.crazyegg.com/blog/how-to-code-an-email-newsletter/)
 - [The RIGHT WAY to create HTML emails | TUTORIAL [2021]](https://www.youtube.com/watch?v=sSNnixkKqcA)
-- [How to HTML: Your Guide to Designing and Coding Emails That Deliver](https://customer.io/blog/how-to-html-your-guide-to-designing-and-coding-emails-that-deliver/)
+- [A Complete Guide To HTML Email](https://www.smashingmagazine.com/2021/04/complete-guide-html-email-templates-tools/)
+- [How to Code a Responsive Email from Scratch](https://litmus.com/community/learning/24-how-to-code-a-responsive-email-from-scratch)
 - [Build an HTML Email Template From Scratch](https://webdesign.tutsplus.com/articles/build-an-html-email-template-from-scratch--webdesign-12770)
 - [A Complete Guide To Create Your Own HTML Email](https://email.uplers.com/blog/step-step-guide-create-html-email/)
+- [How to HTML: Your Guide to Designing and Coding Emails That Deliver](https://customer.io/blog/how-to-html-your-guide-to-designing-and-coding-emails-that-deliver/)
+- [How to Code a Mobile-First Responsive Email Template [Tutorial]](https://designmodo.com/code-responsive-email-template/)
+- [Coding HTML emails](https://www.campaignmonitor.com/dev-resources/guides/coding-html-emails/)
+- [HTML Email Development Best Practices: Rules to Code By](https://www.emailonacid.com/blog/article/email-development/email-development-best-practices-2/)
+- [The Most Common Email Coding Mistakes and How to Avoid Them](https://sendpulse.com/blog/email-coding-mistakes)
 - [Email Coding vs Web Coding: It’s Not The Same](https://smaily.com/email-coding-vs-web-coding-its-not-the-same/)
 - [Email Coding Guidelines](https://gist.github.com/janogarcia/4977a2346cbc7e52334b)
+
+#### HTML Email Templates
+
+- [Responsive Email Templates](https://zurb.com/playground/responsive-email-templates)
 - [Free HTML Email Templates](https://github.com/designmodo/html-email-templates)
 - [Responsive Email](https://github.com/derekpunsalan/responsive-email)
-- [How to Code a Mobile-First Responsive Email Template [Tutorial]](https://designmodo.com/code-responsive-email-template/)
-- [Unlayer. Create beautiful emails, easily.](unlayer.com)
-- [Codepen Email Templates](https://codepen.io/collection/AyVBJr)
-- [Really good email](https://reallygoodemails.com/)
-- [Benchmarkemail. Email Marketing Templates](https://www.benchmarkemail.com/email-templates/)
-- [An intuitive email builder for teams and individuals amps up email marketing ideas](https://designmodo.com/postcards/)
+- [CodePen Email Templates](https://codepen.io/collection/AyVBJr)
+- [Really Good Emails](https://reallygoodemails.com/)
+- [Benchmark Email Marketing Templates](https://www.benchmarkemail.com/email-templates/)
 - [1210+ Free HTML Professional Email Templates](https://beefree.io/templates/)
+- [Unlayer](https://unlayer.com) — create beautiful emails easily
+- [Postcards](https://designmodo.com/postcards/) — intuitive email builder for teams and individuals
+
 
 ## Github Repositories
 

--- a/website/docs/development/frontend-development.md
+++ b/website/docs/development/frontend-development.md
@@ -1,13 +1,12 @@
 ---
 title: "Frontend Development"
-description: "Frontend Development — curated development resources from the Awesome Email Marketing library."
+description: "Learn HTML email coding and browse curated HTML email template collections for marketing and transactional mail."
 keywords:
   - html email
   - email coding
-  - development
   - frontend development
-  - awesome email marketing
-  - email marketing
+  - email templates
+  - responsive email
 sidebar_label: "Frontend Development"
 sidebar_position: 1
 image: img/docusaurus-social-card.jpg
@@ -20,11 +19,12 @@ unlisted: false
 category: development
 topics:
   - development
+  - html-email
 audience:
   - developers
 seo:
   title: "Frontend Development | Awesome Email Marketing"
-  description: "Frontend Development — curated development resources from the Awesome Email Marketing library."
+  description: "Learn HTML email coding and browse curated HTML email template collections for marketing and transactional mail."
   robots: index,follow
   canonical_path: "/docs/development/frontend-development"
   og_type: article
@@ -33,28 +33,18 @@ seo:
 
 # Frontend Development
 
-- [Responsive Email Templates](https://zurb.com/playground/responsive-email-templates)
-- [The Most Common Email Coding Mistakes and How to Avoid Them](https://sendpulse.com/blog/email-coding-mistakes)
-- [How to Code a Responsive Email from Scratch](https://litmus.com/community/learning/24-how-to-code-a-responsive-email-from-scratch)
-- [HTML Email Development Best Practices: Rules to Code By](https://www.emailonacid.com/blog/article/email-development/email-development-best-practices-2/)
-- [How To Code An Email Newsletter in 6 Simple Steps](https://www.crazyegg.com/blog/how-to-code-an-email-newsletter/)
-- [HTML Email Basics](https://templates.mailchimp.com/getting-started/html-email-basics/)
-- [A Complete Guide To HTML Email](https://www.smashingmagazine.com/2021/04/complete-guide-html-email-templates-tools/)
-- [Coding html emails](https://www.campaignmonitor.com/dev-resources/guides/coding-html-emails/)
-- [New to email coding? Here’s where to start](https://explore.reallygoodemails.com/new-to-email-coding-heres-where-to-start-2494422f0bd4)
-- [The RIGHT WAY to create HTML emails | TUTORIAL [2021]](https://www.youtube.com/watch?v=sSNnixkKqcA)
-- [How to HTML: Your Guide to Designing and Coding Emails That Deliver](https://customer.io/blog/how-to-html-your-guide-to-designing-and-coding-emails-that-deliver/)
-- [Build an HTML Email Template From Scratch](https://webdesign.tutsplus.com/articles/build-an-html-email-template-from-scratch--webdesign-12770)
-- [A Complete Guide To Create Your Own HTML Email](https://email.uplers.com/blog/step-step-guide-create-html-email/)
-- [Email Coding vs Web Coding: It’s Not The Same](https://smaily.com/email-coding-vs-web-coding-its-not-the-same/)
-- [Email Coding Guidelines](https://gist.github.com/janogarcia/4977a2346cbc7e52334b)
-- [Free HTML Email Templates](https://github.com/designmodo/html-email-templates)
-- [Responsive Email](https://github.com/derekpunsalan/responsive-email)
-- [How to Code a Mobile-First Responsive Email Template [Tutorial]](https://designmodo.com/code-responsive-email-template/)
-- [Unlayer. Create beautiful emails, easily.](https://unlayer.com)
-- [Codepen Email Templates](https://codepen.io/collection/AyVBJr)
-- [Really good email](https://reallygoodemails.com/)
-- [Benchmarkemail. Email Marketing Templates](https://www.benchmarkemail.com/email-templates/)
-- [An intuitive email builder for teams and individuals amps up email marketing ideas](https://designmodo.com/postcards/)
-- [1210+ Free HTML Professional Email Templates](https://beefree.io/templates/)
+Resources for building HTML emails — split so tutorials stay separate from template collections.
 
+## Browse by section
+
+| Section | What you’ll find |
+| --- | --- |
+| [Articles & Tutorials](./html-email-tutorials) | Guides, coding lessons, and best practices |
+| [HTML Email Templates](./html-email-templates) | Template packs, galleries, and builders |
+
+## Related
+
+- [GitHub Repositories](./github-repositories)
+- [Cool Projects](./cool-projects)
+- [Email Builders & Templates](/docs/tools/email-builders)
+- [Explore templates](/explore?tag=templates)

--- a/website/docs/development/html-email-templates.md
+++ b/website/docs/development/html-email-templates.md
@@ -1,0 +1,59 @@
+---
+title: "HTML Email Templates"
+description: "Collections of HTML email templates, galleries, and visual builders for marketing and transactional email design."
+keywords:
+  - html email templates
+  - free email templates
+  - email template gallery
+  - responsive email templates
+sidebar_label: "HTML Templates"
+sidebar_position: 3
+image: img/docusaurus-social-card.jpg
+hide_title: false
+hide_table_of_contents: false
+toc_min_heading_level: 2
+toc_max_heading_level: 3
+draft: false
+unlisted: false
+category: development
+topics:
+  - development
+  - templates
+  - html-email
+audience:
+  - developers
+  - marketers
+seo:
+  title: "HTML Email Templates | Awesome Email Marketing"
+  description: "Collections of HTML email templates, galleries, and visual builders for marketing and transactional email design."
+  robots: index,follow
+  canonical_path: "/docs/development/html-email-templates"
+  og_type: article
+  twitter_card: summary_large_image
+---
+
+# HTML Email Templates
+
+Template collections, galleries, and builders — separate from coding tutorials.
+
+## Template collections & galleries
+
+- [Responsive Email Templates](https://zurb.com/playground/responsive-email-templates)
+- [Free HTML Email Templates](https://github.com/designmodo/html-email-templates)
+- [Responsive Email](https://github.com/derekpunsalan/responsive-email)
+- [CodePen Email Templates](https://codepen.io/collection/AyVBJr)
+- [Really Good Emails](https://reallygoodemails.com/)
+- [Benchmark Email Marketing Templates](https://www.benchmarkemail.com/email-templates/)
+- [1210+ Free HTML Professional Email Templates](https://beefree.io/templates/)
+
+## Visual builders
+
+- [Unlayer](https://unlayer.com) — create beautiful emails easily
+- [Postcards](https://designmodo.com/postcards/) — intuitive email builder for teams and individuals
+
+## Related lists
+
+- [Articles & Tutorials](./html-email-tutorials)
+- [GitHub Repositories](./github-repositories)
+- [Email Builders & Templates](/docs/tools/email-builders)
+- [Filter templates on Explore](/explore?tag=templates)

--- a/website/docs/development/html-email-tutorials.md
+++ b/website/docs/development/html-email-tutorials.md
@@ -1,0 +1,62 @@
+---
+title: "HTML Email Tutorials"
+description: "Articles and tutorials for learning HTML email coding, responsive techniques, and email frontend best practices."
+keywords:
+  - html email tutorials
+  - email coding guide
+  - responsive email tutorial
+  - email development best practices
+sidebar_label: "Articles & Tutorials"
+sidebar_position: 2
+image: img/docusaurus-social-card.jpg
+hide_title: false
+hide_table_of_contents: false
+toc_min_heading_level: 2
+toc_max_heading_level: 3
+draft: false
+unlisted: false
+category: development
+topics:
+  - development
+  - tutorials
+  - html-email
+audience:
+  - developers
+seo:
+  title: "HTML Email Tutorials | Awesome Email Marketing"
+  description: "Articles and tutorials for learning HTML email coding, responsive techniques, and email frontend best practices."
+  robots: index,follow
+  canonical_path: "/docs/development/html-email-tutorials"
+  og_type: article
+  twitter_card: summary_large_image
+---
+
+# Articles & Tutorials
+
+Guides and lessons for coding HTML emails from scratch and avoiding common pitfalls.
+
+## Getting started
+
+- [HTML Email Basics](https://templates.mailchimp.com/getting-started/html-email-basics/)
+- [New to email coding? Here’s where to start](https://explore.reallygoodemails.com/new-to-email-coding-heres-where-to-start-2494422f0bd4)
+- [How To Code An Email Newsletter in 6 Simple Steps](https://www.crazyegg.com/blog/how-to-code-an-email-newsletter/)
+- [The RIGHT WAY to create HTML emails | TUTORIAL [2021]](https://www.youtube.com/watch?v=sSNnixkKqcA)
+
+## Deep guides
+
+- [A Complete Guide To HTML Email](https://www.smashingmagazine.com/2021/04/complete-guide-html-email-templates-tools/)
+- [How to Code a Responsive Email from Scratch](https://litmus.com/community/learning/24-how-to-code-a-responsive-email-from-scratch)
+- [Build an HTML Email Template From Scratch](https://webdesign.tutsplus.com/articles/build-an-html-email-template-from-scratch--webdesign-12770)
+- [A Complete Guide To Create Your Own HTML Email](https://email.uplers.com/blog/step-step-guide-create-html-email/)
+- [How to HTML: Your Guide to Designing and Coding Emails That Deliver](https://customer.io/blog/how-to-html-your-guide-to-designing-and-coding-emails-that-deliver/)
+- [How to Code a Mobile-First Responsive Email Template [Tutorial]](https://designmodo.com/code-responsive-email-template/)
+- [Coding HTML emails](https://www.campaignmonitor.com/dev-resources/guides/coding-html-emails/)
+
+## Best practices & references
+
+- [HTML Email Development Best Practices: Rules to Code By](https://www.emailonacid.com/blog/article/email-development/email-development-best-practices-2/)
+- [The Most Common Email Coding Mistakes and How to Avoid Them](https://sendpulse.com/blog/email-coding-mistakes)
+- [Email Coding vs Web Coding: It’s Not The Same](https://smaily.com/email-coding-vs-web-coding-its-not-the-same/)
+- [Email Coding Guidelines](https://gist.github.com/janogarcia/4977a2346cbc7e52334b)
+
+Looking for ready-made packs instead? See [HTML Email Templates](./html-email-templates).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -114,6 +114,8 @@ const sidebars: SidebarsConfig = {
       },
       items: [
         'development/frontend-development',
+        'development/html-email-tutorials',
+        'development/html-email-templates',
         'development/github-repositories',
         'development/related-repositories',
         'development/cool-projects',

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -36,8 +36,8 @@ const FeatureList: FeatureItem[] = [
     to: '/docs/development/frontend-development',
     description: (
       <>
-        HTML email coding resources, GitHub projects, deliverability guides, and
-        measurement basics.
+        HTML email tutorials, template collections, GitHub projects, and
+        deliverability basics.
       </>
     ),
   },

--- a/website/src/components/HomepageSearch/index.tsx
+++ b/website/src/components/HomepageSearch/index.tsx
@@ -1,0 +1,78 @@
+import {useState, type FormEvent, type ReactNode} from 'react';
+import {useHistory} from '@docusaurus/router';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+import styles from './styles.module.css';
+
+const SUGGESTIONS = [
+  {label: 'Mailchimp', q: 'mailchimp'},
+  {label: 'DKIM', q: 'dkim'},
+  {label: 'Templates', q: 'templates'},
+  {label: 'Self-hosted', q: 'self-hosted'},
+  {label: 'Automation', q: 'automation'},
+];
+
+export default function HomepageSearch(): ReactNode {
+  const history = useHistory();
+  const explorePath = useBaseUrl('/explore');
+  const [query, setQuery] = useState('');
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = query.trim();
+    const params = new URLSearchParams();
+    if (trimmed) {
+      params.set('q', trimmed);
+    }
+    const search = params.toString();
+    history.push(`${explorePath}${search ? `?${search}` : ''}`);
+  };
+
+  return (
+    <div className={styles.wrap}>
+      <form className={styles.form} onSubmit={onSubmit} role="search">
+        <label className={styles.srOnly} htmlFor="homepage-search">
+          Search the email marketing library
+        </label>
+        <div className={styles.field}>
+          <span className={styles.icon} aria-hidden="true">
+            <svg viewBox="0 0 24 24" width="22" height="22" fill="none">
+              <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+              <path
+                d="M20 20l-3.5-3.5"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+          </span>
+          <input
+            id="homepage-search"
+            className={styles.input}
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search tools, templates, deliverability…"
+            autoComplete="off"
+          />
+          <button className={styles.button} type="submit">
+            Search
+          </button>
+        </div>
+      </form>
+      <div className={styles.suggestions}>
+        <span className={styles.suggestionLabel}>Try</span>
+        {SUGGESTIONS.map((item) => (
+          <button
+            key={item.q}
+            type="button"
+            className={styles.chip}
+            onClick={() => history.push(`${explorePath}?q=${encodeURIComponent(item.q)}`)}>
+            {item.label}
+          </button>
+        ))}
+        <span className={styles.hint}>or press Ctrl/⌘ + K in docs</span>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/HomepageSearch/styles.module.css
+++ b/website/src/components/HomepageSearch/styles.module.css
@@ -1,0 +1,156 @@
+.wrap {
+  width: min(720px, 100%);
+  margin: 1.75rem auto 0;
+  text-align: left;
+}
+
+.form {
+  width: 100%;
+}
+
+.field {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.55rem 0.55rem 0.55rem 1rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, #ffffff 92%, transparent);
+  border: 1px solid color-mix(in srgb, #0f6e56 18%, #ffffff);
+  box-shadow:
+    0 18px 40px color-mix(in srgb, #073528 22%, transparent),
+    0 2px 0 color-mix(in srgb, #ffffff 55%, transparent) inset;
+  backdrop-filter: blur(10px);
+}
+
+.icon {
+  display: inline-flex;
+  color: #0f6e56;
+  flex: 0 0 auto;
+}
+
+.input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: #16352c;
+  font: inherit;
+  font-size: 1.05rem;
+  line-height: 1.3;
+}
+
+.input::placeholder {
+  color: color-mix(in srgb, #16352c 45%, transparent);
+}
+
+.button {
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem 1.15rem;
+  background: #0f6e56;
+  color: #fff;
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+  transition: transform 120ms ease, background-color 120ms ease;
+}
+
+.button:hover {
+  background: #0d634d;
+  transform: translateY(-1px);
+}
+
+.suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.85rem;
+  justify-content: center;
+}
+
+.suggestionLabel,
+.hint {
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.chip {
+  border: 1px solid color-mix(in srgb, #ffffff 45%, transparent);
+  background: color-mix(in srgb, #073528 18%, transparent);
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.28rem 0.7rem;
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 120ms ease, transform 120ms ease;
+}
+
+.chip:hover {
+  background: color-mix(in srgb, #073528 30%, transparent);
+  transform: translateY(-1px);
+}
+
+.hint {
+  margin-left: 0.25rem;
+  opacity: 0.8;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media screen and (max-width: 640px) {
+  .field {
+    border-radius: 18px;
+    flex-wrap: wrap;
+    padding: 0.75rem;
+  }
+
+  .icon {
+    margin-left: 0.25rem;
+  }
+
+  .input {
+    flex-basis: calc(100% - 2.5rem);
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .hint {
+    width: 100%;
+    text-align: center;
+    margin-left: 0;
+  }
+}
+
+/* Dark hero text inherits; keep field readable in both modes */
+[data-theme='dark'] .field {
+  background: color-mix(in srgb, #10241d 88%, #ffffff);
+  border-color: color-mix(in srgb, #3ecf9a 28%, transparent);
+}
+
+[data-theme='dark'] .input {
+  color: #e8fff5;
+}
+
+[data-theme='dark'] .input::placeholder {
+  color: color-mix(in srgb, #e8fff5 55%, transparent);
+}
+
+[data-theme='dark'] .icon {
+  color: #3ecf9a;
+}

--- a/website/src/data/catalog.json
+++ b/website/src/data/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-30T03:03:01.759Z",
+  "generatedAt": "2026-07-30T03:21:38.714Z",
   "name": "Awesome Email Marketing catalog",
   "homepage": "https://llazyemail.github.io/awesome-email-marketing/",
   "repository": "https://github.com/LLazyEmail/awesome-email-marketing",

--- a/website/src/data/changelog.json
+++ b/website/src/data/changelog.json
@@ -1,6 +1,15 @@
 [
   {
     "date": "2026-07-30",
+    "title": "Homepage search + Frontend Development split",
+    "items": [
+      "Added a prominent homepage search bar that routes into Explore filters",
+      "Split Frontend Development into Articles & Tutorials and HTML Email Templates",
+      "Mirrored the Frontend Development structure in README.md"
+    ]
+  },
+  {
+    "date": "2026-07-30",
     "title": "Best Tools split, explicit sidebar, SEO frontmatter",
     "items": [
       "Split Best Tools into newsletter, self-hosted, builders, deliverability, growth automation, and ESP pages",

--- a/website/src/data/related.ts
+++ b/website/src/data/related.ts
@@ -91,9 +91,19 @@ export const relatedByDocId: Record<string, RelatedLink[]> = {
     {label: 'Filter deliverability tools', to: '/explore?tag=deliverability'},
   ],
   'development/frontend-development': [
+    {label: 'Articles & Tutorials', to: '/docs/development/html-email-tutorials'},
+    {label: 'HTML Email Templates', to: '/docs/development/html-email-templates'},
     {label: 'GitHub Repositories', to: '/docs/development/github-repositories'},
-    {label: 'HTML Utilities', to: '/docs/development/html-utilities'},
-    {label: 'Email Templates', to: '/docs/guides/email-templates'},
+  ],
+  'development/html-email-tutorials': [
+    {label: 'HTML Email Templates', to: '/docs/development/html-email-templates'},
+    {label: 'Frontend Development overview', to: '/docs/development/frontend-development'},
+    {label: 'Email Coding Checkers', to: '/docs/development/checkers'},
+  ],
+  'development/html-email-templates': [
+    {label: 'Articles & Tutorials', to: '/docs/development/html-email-tutorials'},
+    {label: 'GitHub Repositories', to: '/docs/development/github-repositories'},
+    {label: 'Filter templates', to: '/explore?tag=templates'},
   ],
   'development/github-repositories': [
     {label: 'Frontend Development', to: '/docs/development/frontend-development'},

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -20,4 +20,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -4,6 +4,7 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import HomepageSearch from '@site/src/components/HomepageSearch';
 import MetricsStrip from '@site/src/components/MetricsStrip';
 import Heading from '@theme/Heading';
 
@@ -18,6 +19,7 @@ function HomepageHeader() {
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <HomepageSearch />
         <div className={styles.buttons}>
           <Link className="button button--secondary button--lg" to="/explore">
             Explore & filter

--- a/website/static/api/v1/catalog.json
+++ b/website/static/api/v1/catalog.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-30T03:03:01.759Z",
+  "generatedAt": "2026-07-30T03:21:38.714Z",
   "name": "Awesome Email Marketing catalog",
   "homepage": "https://llazyemail.github.io/awesome-email-marketing/",
   "repository": "https://github.com/LLazyEmail/awesome-email-marketing",

--- a/website/static/api/v1/glossary.json
+++ b/website/static/api/v1/glossary.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-30T03:03:01.759Z",
+  "generatedAt": "2026-07-30T03:21:38.714Z",
   "items": [
     {
       "term": "ESP",

--- a/website/static/api/v1/metrics.json
+++ b/website/static/api/v1/metrics.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-07-30T03:03:01.759Z",
+  "generatedAt": "2026-07-30T03:21:38.714Z",
   "resources": 126,
   "tags": 18,
-  "docsPages": 58,
+  "docsPages": 60,
   "sections": 2,
   "bySection": {
     "development": 44,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a prominent homepage search experience and restructures Frontend Development for easier browsing.

### Homepage search
- New hero search bar with suggestion chips
- Submits into `/explore?q=…` so results use the tagged catalog filters
- Hint for docs local search (`Ctrl/⌘ + K`)

### Frontend Development split
- `frontend-development.md` is now a hub
- `html-email-tutorials.md` — Articles & Tutorials
- `html-email-templates.md` — HTML template collections / galleries / builders
- Explicit sidebar entries + related-resources links updated
- Same structure mirrored in root `README.md` (including TOC)

### Verify
`npm run build` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81aa43e2-2553-4540-81be-cd8a1dec184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81aa43e2-2553-4540-81be-cd8a1dec184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

