### PR TITLE
Auto-generate changelog after each merged pull request

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,61 @@
+name: Update changelog
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: changelog
+  cancel-in-progress: false
+
+jobs:
+  changelog:
+    name: Regenerate changelog
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Checkout the default branch so we commit onto main after a merge.
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate changelog
+        run: npm run changelog
+
+      - name: Commit and push changelog
+        working-directory: .
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add CHANGELOG.md website/src/data/changelog.json
+
+          if git diff --staged --quiet; then
+            echo "Changelog already up to date."
+            exit 0
+          fi
+
+          git commit -m "chore(changelog): regenerate after merged pull request"
+          git push origin HEAD:main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+This changelog is generated automatically from merged pull requests with [`auto-changelog`](https://github.com/CookPete/auto-changelog).
+
+## Unreleased
+
+### Merged
+
+- Complete #226: GitHub repos and Miscellaneous entries ([#227](https://github.com/LLazyEmail/awesome-email-marketing/pull/227))
+- Split Transactional Emails into Articles and Tools (#103) ([#225](https://github.com/LLazyEmail/awesome-email-marketing/pull/225))
+- Add homepage search and split Frontend Development sections ([#224](https://github.com/LLazyEmail/awesome-email-marketing/pull/224))
+- Split Best Tools, sync README, explicit sidebar, SEO frontmatter ([#222](https://github.com/LLazyEmail/awesome-email-marketing/pull/222))
+- Add explore filters, metrics strip, related links, glossary, API, changelog ([#219](https://github.com/LLazyEmail/awesome-email-marketing/pull/219))
+- Migrate open README PR contributions into Docusaurus ([#218](https://github.com/LLazyEmail/awesome-email-marketing/pull/218))
+- Add GitHub Pages deploy, local search, and clearer docs navigation ([#217](https://github.com/LLazyEmail/awesome-email-marketing/pull/217))
+- Split README into separate formatted Docusaurus pages ([#216](https://github.com/LLazyEmail/awesome-email-marketing/pull/216))
+- Add Docusaurus site for Awesome Email Marketing ([#215](https://github.com/LLazyEmail/awesome-email-marketing/pull/215))
+

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 #### A collection of articles, templates, tools, and many more to build and manage emails.
 
+Docs site: [`website/`](./website/). Project history: [`CHANGELOG.md`](./CHANGELOG.md) (auto-generated from merged PRs).
+
 ## Table of Contents
 
 - [Best Email Marketing Tools](#best-email-marketing-tools)

--- a/website/.auto-changelog
+++ b/website/.auto-changelog
@@ -1,0 +1,12 @@
+{
+  "output": "../CHANGELOG.md",
+  "template": "./scripts/changelog-template.hbs",
+  "unreleased": true,
+  "commitLimit": false,
+  "backfillLimit": false,
+  "hideCredit": true,
+  "hideEmptyReleases": true,
+  "startingDate": "2026-07-29",
+  "sortCommits": "date-desc",
+  "ignoreCommitPattern": "^chore\\(changelog\\)|^\\[changelog\\]"
+}

--- a/website/README.md
+++ b/website/README.md
@@ -26,7 +26,7 @@ Local search is enabled with [`@easyops-cn/docusaurus-search-local`](https://git
 
 - `/explore` — tag/filter UI over the curated catalog
 - `/docs/glossary` — email marketing glossary
-- `/docs/changelog` — site/library changelog
+- `/docs/changelog` — site/library changelog (auto-generated from merged PRs)
 - `/docs/api` — public JSON API docs
 - `/api/v1/catalog.json` — machine-readable catalog
 
@@ -36,12 +36,21 @@ Regenerate catalog exports:
 npm run generate:api
 ```
 
+Regenerate the changelog (root `CHANGELOG.md` + `src/data/changelog.json`):
+
+```bash
+npm run changelog
+```
+
+Uses the [`auto-changelog`](https://www.npmjs.com/package/auto-changelog) npm package. Config lives in [`.auto-changelog`](./.auto-changelog).
+
 ## Automatic deployment
 
 GitHub Actions workflows live in [`.github/workflows/`](../.github/workflows):
 
 - `test-deploy.yml` — builds the site on pull requests
 - `deploy.yml` — builds and deploys to GitHub Pages on pushes to `main`
+- `changelog.yml` — regenerates `CHANGELOG.md` and the docs changelog after each merged PR to `main`
 
 ### One-time GitHub Pages setup
 

--- a/website/docs/changelog.mdx
+++ b/website/docs/changelog.mdx
@@ -36,6 +36,8 @@ import changelog from '@site/src/data/changelog.json';
 
 Notable updates to the documentation site and curated library.
 
+Entries are generated automatically from merged pull requests via [`auto-changelog`](https://www.npmjs.com/package/auto-changelog). Run `npm run changelog` in `website/` locally, or rely on the **Update changelog** GitHub Action after each merge to `main`.
+
 {changelog.map((entry) => (
   <section key={`${entry.date}-${entry.title}`}>
     <h2>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -23,6 +23,7 @@
         "@docusaurus/tsconfig": "3.10.2",
         "@docusaurus/types": "3.10.2",
         "@types/react": "^19.0.0",
+        "auto-changelog": "^2.6.0",
         "typescript": "~6.0.2"
       },
       "engines": {
@@ -7246,6 +7247,36 @@
         "astring": "bin/astring"
       }
     },
+    "node_modules/auto-changelog": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.6.0.tgz",
+      "integrity": "sha512-jJgUkuWXQ7fPLPXOMQk/XSSmy7KvzpzhjJa6w660dq1KTEez/GW2CPckBra3jMMMMpcwxp84bOslo29qRCewzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "handlebars": "^4.7.9",
+        "import-cwd": "^3.0.0",
+        "parse-github-url": "^1.0.4",
+        "semver": "^7.8.1"
+      },
+      "bin": {
+        "auto-changelog": "src/index.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/auto-changelog/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.4",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
@@ -10314,6 +10345,38 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -10922,6 +10985,19 @@
       "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
       "license": "MIT"
     },
+    "node_modules/import-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
+      "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-from": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10936,6 +11012,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/import-from/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/import-lazy": {
@@ -14963,6 +15062,19 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse-github-url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.4.tgz",
+      "integrity": "sha512-CEtCOt55fHmd6DpBc/N7H5NC4vJpcquhzzs9Iw2mRj8bVxo1O5TQI5MXKOMO7+yBOqD+5dKCCRK4Kj1KskZc6Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "parse-github-url": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -18859,6 +18971,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
@@ -19797,6 +19923,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/website/package.json
+++ b/website/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "generate:api": "node ./scripts/generate-catalog.mjs",
+    "generate:changelog": "node ./scripts/generate-changelog.mjs",
+    "changelog": "npm run generate:changelog",
     "prestart": "npm run generate:api",
     "start": "docusaurus start",
     "prebuild": "npm run generate:api",
@@ -33,6 +35,7 @@
     "@docusaurus/tsconfig": "3.10.2",
     "@docusaurus/types": "3.10.2",
     "@types/react": "^19.0.0",
+    "auto-changelog": "^2.6.0",
     "typescript": "~6.0.2"
   },
   "browserslist": {

--- a/website/scripts/changelog-template.hbs
+++ b/website/scripts/changelog-template.hbs
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+This changelog is generated automatically from merged pull requests with [`auto-changelog`](https://github.com/CookPete/auto-changelog).
+
+{{#each releases}}
+{{#if href}}
+## [{{title}}]({{href}}){{#if tag}} — {{isoDate}}{{/if}}
+{{else}}
+## {{title}}{{#if tag}} — {{isoDate}}{{/if}}
+{{/if}}
+
+{{#if summary}}
+{{summary}}
+
+{{/if}}
+{{#if merges}}
+### Merged
+
+{{#each merges}}
+- {{#if commit.breaking}}**Breaking change:** {{/if}}{{message}}{{#if href}} ([#{{id}}]({{href}})){{/if}}
+{{/each}}
+
+{{/if}}
+{{#if fixes}}
+### Fixed
+
+{{#each fixes}}
+- {{#if commit.breaking}}**Breaking change:** {{/if}}{{commit.subject}}{{#each fixes}}{{#if href}} ([#{{id}}]({{href}})){{/if}}{{/each}}
+{{/each}}
+
+{{/if}}
+{{/each}}

--- a/website/scripts/generate-changelog.mjs
+++ b/website/scripts/generate-changelog.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Generate CHANGELOG.md and website/src/data/changelog.json from git history
+ * using the auto-changelog npm package (merged PRs).
+ */
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const websiteDir = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(websiteDir, '..');
+const changelogMdPath = path.join(repoRoot, 'CHANGELOG.md');
+const changelogJsonPath = path.join(websiteDir, 'src/data/changelog.json');
+const configPath = path.join(websiteDir, '.auto-changelog');
+
+const autoChangelogBin = path.join(
+  websiteDir,
+  'node_modules',
+  '.bin',
+  'auto-changelog',
+);
+
+function loadConfig() {
+  const defaults = {
+    startingDate: '2026-07-29',
+    ignoreCommitPattern: '^chore\\(changelog\\)|^\\[changelog\\]',
+  };
+  try {
+    return {...defaults, ...JSON.parse(fs.readFileSync(configPath, 'utf8'))};
+  } catch {
+    return defaults;
+  }
+}
+
+function runAutoChangelogJson(config) {
+  const args = [
+    '--stdout',
+    '--template',
+    'json',
+    '--unreleased',
+    '--commit-limit',
+    'false',
+    '--hide-credit',
+    '--sort-commits',
+    'date-desc',
+  ];
+
+  if (config.ignoreCommitPattern) {
+    args.push('--ignore-commit-pattern', config.ignoreCommitPattern);
+  }
+
+  return execFileSync(autoChangelogBin, args, {
+    cwd: websiteDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+}
+
+function toIsoDate(value) {
+  if (!value) {
+    return new Date().toISOString().slice(0, 10);
+  }
+  return String(value).slice(0, 10);
+}
+
+function collectMerges(releases, startingDate) {
+  const merges = [];
+  for (const release of releases) {
+    for (const merge of release.merges ?? []) {
+      const date = toIsoDate(merge.commit?.date ?? release.isoDate);
+      if (startingDate && date < startingDate) {
+        continue;
+      }
+      merges.push({
+        id: merge.id,
+        message: (merge.message || merge.commit?.subject || 'Merged pull request').trim(),
+        href: merge.href,
+        date,
+        author: merge.author,
+      });
+    }
+  }
+  return merges;
+}
+
+function buildSiteChangelog(merges) {
+  return merges.map((merge) => {
+    const prRef = merge.id ? `#${merge.id}` : null;
+    const items = [
+      prRef ? `Merged pull request ${prRef}` : 'Merged pull request',
+    ];
+    if (merge.href) {
+      items.push(merge.href);
+    }
+    return {
+      date: merge.date,
+      title: merge.message,
+      items,
+    };
+  });
+}
+
+function buildMarkdown(merges) {
+  const lines = [
+    '# Changelog',
+    '',
+    'All notable changes to this project are documented in this file.',
+    '',
+    'This changelog is generated automatically from merged pull requests with [`auto-changelog`](https://github.com/CookPete/auto-changelog).',
+    '',
+    '## Unreleased',
+    '',
+    '### Merged',
+    '',
+  ];
+
+  for (const merge of merges) {
+    const link = merge.href && merge.id ? ` ([#${merge.id}](${merge.href}))` : '';
+    lines.push(`- ${merge.message}${link}`);
+  }
+
+  if (merges.length === 0) {
+    lines.push('- _No merged pull requests in range yet._');
+  }
+
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+const config = loadConfig();
+console.log('Fetching merged PR history with auto-changelog…');
+const releases = JSON.parse(runAutoChangelogJson(config));
+const merges = collectMerges(releases, config.startingDate);
+
+console.log(`Writing ${changelogMdPath} (${merges.length} merges since ${config.startingDate})…`);
+fs.writeFileSync(changelogMdPath, buildMarkdown(merges), 'utf8');
+
+const siteEntries = buildSiteChangelog(merges);
+console.log(`Writing ${changelogJsonPath}…`);
+fs.writeFileSync(
+  changelogJsonPath,
+  `${JSON.stringify(siteEntries, null, 2)}\n`,
+  'utf8',
+);
+
+console.log(`Done. ${siteEntries.length} changelog entries.`);

--- a/website/src/data/changelog.json
+++ b/website/src/data/changelog.json
@@ -1,77 +1,74 @@
 [
   {
     "date": "2026-07-30",
-    "title": "GitHub repos and Miscellaneous from open issues",
+    "title": "Complete #226: GitHub repos and Miscellaneous entries",
     "items": [
-      "Added Responsive HTML Email Template (charlesmudy) and Tutanota to GitHub Repositories (issues #194, #188)",
-      "Confirmed Colorlib, konsav, and EmailEngine entries in GitHub Repositories (issues #195, #192, #190)",
-      "Added StampReady, Correlated, and email-team articles to Miscellaneous (issues #186, #189, #191)",
-      "Synced the same entries in README.md"
+      "Merged pull request #227",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/227"
     ]
   },
   {
     "date": "2026-07-30",
-    "title": "Transactional Emails: Articles and Tools",
+    "title": "Split Transactional Emails into Articles and Tools (#103)",
     "items": [
-      "Split Transactional Emails into Articles and Tools subsections (issue #103)",
-      "Mirrored the same structure in README.md",
-      "Updated sidebar and related-resources links"
+      "Merged pull request #225",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/225"
     ]
   },
   {
     "date": "2026-07-30",
-    "title": "Homepage search + Frontend Development split",
+    "title": "Add homepage search and split Frontend Development sections",
     "items": [
-      "Added a prominent homepage search bar that routes into Explore filters",
-      "Split Frontend Development into Articles & Tutorials and HTML Email Templates",
-      "Mirrored the Frontend Development structure in README.md"
+      "Merged pull request #224",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/224"
     ]
   },
   {
     "date": "2026-07-30",
-    "title": "Best Tools split, explicit sidebar, SEO frontmatter",
+    "title": "Split Best Tools, sync README, explicit sidebar, SEO frontmatter",
     "items": [
-      "Split Best Tools into newsletter, self-hosted, builders, deliverability, growth automation, and ESP pages",
-      "Synced the same Best Tools structure into README.md and deduplicated entries",
-      "Kept the docs sidebar fully explicit/manual (no filesystem autogeneration)",
-      "Added advanced SEO frontmatter (description, keywords, topics, audience, canonical, robots, social cards) to all docs pages"
+      "Merged pull request #222",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/222"
     ]
   },
   {
     "date": "2026-07-30",
-    "title": "Explore, API, glossary, and related links",
+    "title": "Add explore filters, metrics strip, related links, glossary, API, changelog",
     "items": [
-      "Added tag/filter Explore page for curated tools and repositories",
-      "Added live metrics strip on the homepage",
-      "Added related resources blocks on documentation pages",
-      "Added glossary of email marketing terms",
-      "Added public JSON API under /api/v1/",
-      "Added project changelog"
+      "Merged pull request #219",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/219"
     ]
   },
   {
     "date": "2026-07-30",
-    "title": "Migrated open README contributions",
+    "title": "Migrate open README PR contributions into Docusaurus",
     "items": [
-      "Imported tools and resources from community PRs into docs and README",
-      "Added Sequenzy, SalesLabel, Wraps, Overloop CLI, DNSai, Campaign Cleaner, EmailQo, and more"
+      "Merged pull request #218",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/218"
     ]
   },
   {
     "date": "2026-07-30",
-    "title": "Deploy, search, and clearer navigation",
+    "title": "Add GitHub Pages deploy, local search, and clearer docs navigation",
     "items": [
-      "Enabled GitHub Pages deploy workflows",
-      "Added local search",
-      "Restructured sidebar into nested, scannable sections"
+      "Merged pull request #217",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/217"
     ]
   },
   {
     "date": "2026-07-29",
-    "title": "Docusaurus site launched",
+    "title": "Split README into separate formatted Docusaurus pages",
     "items": [
-      "Scaffolded the documentation website under website/",
-      "Split the awesome list README into focused docs pages"
+      "Merged pull request #216",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/216"
+    ]
+  },
+  {
+    "date": "2026-07-29",
+    "title": "Add Docusaurus site for Awesome Email Marketing",
+    "items": [
+      "Merged pull request #215",
+      "https://github.com/LLazyEmail/awesome-email-marketing/pull/215"
     ]
   }
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds [`auto-changelog`](https://www.npmjs.com/package/auto-changelog) and a GitHub Action so merged PRs are reflected in the project changelog automatically.

### What was added
- **`npm run changelog`** in `website/` — regenerates root `CHANGELOG.md` and `website/src/data/changelog.json` from merged PRs (since `2026-07-29`, configurable in `website/.auto-changelog`)
- **`.github/workflows/changelog.yml`** — on each merged PR to `main` (or manual dispatch), regenerates the changelog files and commits `chore(changelog): …` back to `main`
- Docs/README notes for the new workflow

### Local usage
```bash
cd website
npm ci
npm run changelog
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81aa43e2-2553-4540-81be-cd8a1dec184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81aa43e2-2553-4540-81be-cd8a1dec184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

