### PR TITLE
Apply #223: LLM/docs plugins for copy, llms.txt, and AgentReady

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 #### A collection of articles, templates, tools, and many more to build and manage emails.
 
-Docs site: [`website/`](./website/). Project history: [`CHANGELOG.md`](./CHANGELOG.md) (auto-generated from merged PRs).
+Docs site: [`website/`](./website/). Project history: [`CHANGELOG.md`](./CHANGELOG.md) (auto-generated from merged PRs). LLM-friendly exports: `/llms.txt` and `/llms-full.txt` on the published site.
 
 ## Table of Contents
 

--- a/website/README.md
+++ b/website/README.md
@@ -22,6 +22,17 @@ Useful commands:
 
 Local search is enabled with [`@easyops-cn/docusaurus-search-local`](https://github.com/easyops-cn/docusaurus-search-local). Use the search box in the navbar or press `Ctrl/⌘ + K`.
 
+## LLM / agent addons (issue #223)
+
+Configured in `docusaurus.config.ts`:
+
+| Package | Role |
+| --- | --- |
+| [`docusaurus-plugin-copy-page-button`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) | Copy page as Markdown; open in ChatGPT / Claude / Gemini / Perplexity; AgentReady MCP install links |
+| [`docusaurus-plugin-llms`](https://www.npmjs.com/package/docusaurus-plugin-llms) | Generates `llms.txt`, `llms-full.txt`, and per-page Markdown (covers the `docusaurus-plugin-llms-txt` use case) |
+| [`docusaurus-markdown-source-plugin`](https://www.npmjs.com/package/docusaurus-markdown-source-plugin) | Exposes docs as raw `.md` URLs |
+| [`@agentreadyweb/docusaurus-plugin`](https://www.npmjs.com/package/@agentreadyweb/docusaurus-plugin) | Re-indexes the site in [AgentReady](https://www.agentready.it.com/) after each build |
+
 ## Explore, API, glossary
 
 - `/explore` — tag/filter UI over the curated catalog
@@ -29,6 +40,8 @@ Local search is enabled with [`@easyops-cn/docusaurus-search-local`](https://git
 - `/docs/changelog` — site/library changelog (auto-generated from merged PRs)
 - `/docs/api` — public JSON API docs
 - `/api/v1/catalog.json` — machine-readable catalog
+- `/llms.txt` / `/llms-full.txt` — LLM-friendly docs index and full corpus ([llmstxt.org](https://llmstxt.org/))
+- Docs pages include a **Copy page** button (Markdown + AI tools) and raw `.md` source URLs
 
 Regenerate catalog exports:
 

--- a/website/docs/api.mdx
+++ b/website/docs/api.mdx
@@ -72,6 +72,18 @@ curl -s https://llazyemail.github.io/awesome-email-marketing/api/v1/catalog.json
 
 Filter client-side by tag, or use the interactive [Explore](/explore) page.
 
+## LLM / agent exports
+
+Built automatically with each site build (see issue [#223](https://github.com/LLazyEmail/awesome-email-marketing/issues/223)):
+
+| Path | Description |
+| --- | --- |
+| [`/llms.txt`](pathname:///llms.txt) | [llmstxt.org](https://llmstxt.org/) index of documentation pages |
+| [`/llms-full.txt`](pathname:///llms-full.txt) | Full docs corpus concatenated for LLM context |
+| Doc `.md` URLs | Append `.md` to a docs URL (via markdown source plugin), or use per-page markdown files from the LLMs plugin |
+| Copy page button | On docs pages — copy clean Markdown or open in ChatGPT / Claude / Gemini / Perplexity |
+| [AgentReady MCP](https://www.agentready.it.com/api/mcp) | Docs are re-indexed after each production build for MCP clients |
+
 ## Regenerating locally
 
 ```bash
@@ -80,3 +92,4 @@ npm run generate:api
 ```
 
 The generator parses selected docs pages into `src/data/catalog.json` and `static/api/v1/*`.
+LLM files (`llms.txt`, `llms-full.txt`, per-page markdown) are produced during `npm run build`.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -71,6 +71,55 @@ const config: Config = {
     ],
   ],
 
+  plugins: [
+    [
+      'docusaurus-plugin-copy-page-button',
+      {
+        placement: 'toc',
+        mcpServer: {
+          name: 'awesome-email-marketing',
+          url: 'https://www.agentready.it.com/api/mcp',
+        },
+      },
+    ],
+    [
+      'docusaurus-plugin-llms',
+      {
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        generateMarkdownFiles: true,
+        docsDir: 'docs',
+        title: 'Awesome Email Marketing',
+        description:
+          'Curated articles, templates, tools, and resources for building and managing email marketing.',
+        includeBlog: false,
+        excludeImports: true,
+        removeDuplicateHeadings: true,
+        includeUnmatchedLast: true,
+        includeOrder: [
+          'intro.md',
+          'tools/*',
+          'strategy/*',
+          'guides/*',
+          'development/*',
+          'operations/*',
+          'more/*',
+          'glossary.mdx',
+          'api.mdx',
+          'changelog.mdx',
+        ],
+      },
+    ],
+    'docusaurus-markdown-source-plugin',
+    [
+      '@agentreadyweb/docusaurus-plugin',
+      {
+        // GitHub Pages project site; AgentReady indexes this path after each build.
+        domain: 'llazyemail.github.io/awesome-email-marketing',
+      },
+    ],
+  ],
+
   themeConfig: {
     image: 'img/docusaurus-social-card.jpg',
     colorMode: {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,12 +8,16 @@
       "name": "awesome-email-marketing-website",
       "version": "0.0.0",
       "dependencies": {
+        "@agentreadyweb/docusaurus-plugin": "^1.0.2",
         "@docusaurus/core": "3.10.2",
         "@docusaurus/faster": "3.10.2",
         "@docusaurus/preset-classic": "3.10.2",
         "@easyops-cn/docusaurus-search-local": "^0.55.3",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "docusaurus-markdown-source-plugin": "^2.2.5",
+        "docusaurus-plugin-copy-page-button": "^0.8.4",
+        "docusaurus-plugin-llms": "^0.5.1",
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -43,6 +47,23 @@
       },
       "engines": {
         "node": ">=11"
+      }
+    },
+    "node_modules/@agentreadyweb/docusaurus-plugin": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@agentreadyweb/docusaurus-plugin/-/docusaurus-plugin-1.0.2.tgz",
+      "integrity": "sha512-xggqdhKKg7W0l6nyqd/xvi81ipnmIuMZC1wXGZkM1FauMxoKMF1Bfnd5VgKJ49ZkOJwbmK/CmNkqJQvWDcmKPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/core": {
+          "optional": true
+        }
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -9112,6 +9133,81 @@
         "node": ">=6"
       }
     },
+    "node_modules/docusaurus-markdown-source-plugin": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/docusaurus-markdown-source-plugin/-/docusaurus-markdown-source-plugin-2.2.5.tgz",
+      "integrity": "sha512-UP/ilYJ66Yyt+8wjFzRK7xYLm6z4QxZy6fo6myvjtV5MNi1SKhbaPTBMD/sZjn2icCtsFlpwL+rf9JEpaw3VSA==",
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.8.4.tgz",
+      "integrity": "sha512-OBWmUEFIqR3BJ5giae6D518b69ZfZQ5HKrazrY2IPA6tDNX2F3m1ejeyE0oqcVcE7GVkE+K0+vJ5T+kIos8u1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.5.1.tgz",
+      "integrity": "sha512-4kNSK+TU67Y+pV45MJhvkW2ISNDh3SYet8PcPvwShV3VL/Ydwpvms0pTgvmOx1GEdLtJMYjD4PNkdmO3kAvLyw==",
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "4.0.3",
+        "minimatch": "9.0.3",
+        "yaml": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rachfop"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -9465,6 +9561,19 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esrecurse": {
@@ -10323,6 +10432,43 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -18382,6 +18528,12 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/srcset": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
@@ -20080,6 +20232,18 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/website/package.json
+++ b/website/package.json
@@ -20,12 +20,16 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@agentreadyweb/docusaurus-plugin": "^1.0.2",
     "@docusaurus/core": "3.10.2",
     "@docusaurus/faster": "3.10.2",
     "@docusaurus/preset-classic": "3.10.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.3",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
+    "docusaurus-markdown-source-plugin": "^2.2.5",
+    "docusaurus-plugin-copy-page-button": "^0.8.4",
+    "docusaurus-plugin-llms": "^0.5.1",
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -34,6 +34,50 @@
   line-height: 1.55;
 }
 
+/* Markdown source plugin: keep page actions aligned with the title */
+article .markdown header {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  overflow: visible;
+}
+
+article .markdown header h1 {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
+.markdown-actions-container {
+  flex-shrink: 0;
+  margin-left: auto;
+  position: relative;
+}
+
+.markdown-actions-container .dropdown {
+  position: relative;
+}
+
+.markdown-actions-container .dropdown__menu {
+  z-index: 1000;
+  min-width: 220px;
+  right: auto;
+  left: 0;
+}
+
+@media (max-width: 768px) {
+  .markdown-actions-container {
+    margin-bottom: 1rem;
+  }
+
+  .markdown-actions-container .dropdown__menu {
+    right: 0;
+    left: auto;
+    min-width: min(220px, calc(100vw - 2rem));
+    max-width: calc(100vw - 2rem);
+  }
+}
+
 .theme-doc-markdown.markdown table {
   display: table;
   width: 100%;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #223

## Summary

Adds the Docusaurus addons from [#223](https://github.com/LLazyEmail/awesome-email-marketing/issues/223) so docs are easier for humans and AI agents to consume.

| From #223 | Package used | Status |
| --- | --- | --- |
| Copy page button | `docusaurus-plugin-copy-page-button` | Added (TOC placement + AI/MCP actions) |
| llms.txt generation | `docusaurus-plugin-llms` | Added (`llms.txt`, `llms-full.txt`, per-page `.md`) |
| `docusaurus-plugin-llms-txt` | — | Covered by `docusaurus-plugin-llms` (not installed separately) |
| Expose Markdown | `docusaurus-markdown-source-plugin` | Added (raw `.md` URLs; npm name for the FlyNumber plugin) |
| AgentReady | `@agentreadyweb/docusaurus-plugin` | Added (indexes `llazyemail.github.io/awesome-email-marketing` after build) |

Also documents the new exports in `website/README.md`, root `README.md`, and `/docs/api`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81aa43e2-2553-4540-81be-cd8a1dec184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81aa43e2-2553-4540-81be-cd8a1dec184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

