### PR TITLE
Use Helvetica Neue with Eightshift-like typography

### DIFF
--- a/website/src/components/MetricsStrip/styles.module.css
+++ b/website/src/components/MetricsStrip/styles.module.css
@@ -21,7 +21,10 @@
 
 .value {
   display: block;
-  font-size: 1.75rem;
+  font-size: clamp(1.5rem, calc(1.25rem + 0.9vw), 2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1;
   font-weight: 750;
   line-height: 1.1;
   color: var(--ifm-color-primary);

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,5 +1,6 @@
 /**
  * Global theme tweaks for an easy-to-scan resource list.
+ * Typography mirrors Eightshift-style grotesk scale with Helvetica Neue.
  */
 
 :root {
@@ -10,9 +11,37 @@
   --ifm-color-primary-light: #11795f;
   --ifm-color-primary-lighter: #127f64;
   --ifm-color-primary-lightest: #159372;
-  --ifm-code-font-size: 95%;
-  --ifm-leading: 1.65;
+
+  --aem-font-sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --ifm-font-family-base: var(--aem-font-sans);
+  --ifm-heading-font-family: var(--aem-font-sans);
+  --ifm-font-family-monospace: ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --ifm-font-size-base: 17px;
+  --ifm-line-height-base: 1.55;
+  --ifm-leading: 1.55;
   --ifm-list-left-padding: 1.35rem;
+
+  --ifm-heading-font-weight: 700;
+  --ifm-heading-line-height: 1.15;
+  --ifm-h1-font-size: clamp(2.25rem, calc(1.65rem + 2.4vw), 3.5rem);
+  --ifm-h2-font-size: clamp(1.65rem, calc(1.35rem + 1.1vw), 2.25rem);
+  --ifm-h3-font-size: clamp(1.3rem, calc(1.15rem + 0.55vw), 1.65rem);
+  --ifm-h4-font-size: 1.2rem;
+  --ifm-h5-font-size: 1.05rem;
+  --ifm-h6-font-size: 0.95rem;
+
+  /* Display / hero title — Eightshift .es-big-title scale */
+  --aem-display-size: clamp(
+    3.7074202030286756rem,
+    calc(2.59935rem + 5.54035vw),
+    7.9180844472589476rem
+  );
+  --aem-display-tracking: -0.0208em;
+  --aem-display-leading: 0.98;
+
+  --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
@@ -96,6 +125,68 @@ article .markdown header h1 {
 
 .navbar__title {
   font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+html {
+  font-family: var(--aem-font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.hero__title,
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  font-family: var(--aem-font-sans);
+  font-weight: var(--ifm-heading-font-weight);
+  letter-spacing: -0.02em;
+}
+
+h1,
+.markdown h1,
+article .markdown header h1 {
+  letter-spacing: var(--aem-display-tracking);
+  line-height: 1.05;
+}
+
+.hero__title,
+.aem-big-title {
+  font-family: var(--aem-font-sans);
+  font-size: var(--aem-display-size);
+  font-weight: 700;
+  letter-spacing: var(--aem-display-tracking);
+  line-height: var(--aem-display-leading);
+}
+
+.hero__subtitle {
+  font-family: var(--aem-font-sans);
+  font-size: clamp(1.05rem, calc(0.95rem + 0.45vw), 1.35rem);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.45;
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.menu__link,
+.navbar__link,
+.breadcrumbs__link,
+.pagination-nav__label,
+.table-of-contents__link,
+.button {
+  font-family: var(--aem-font-sans);
 }
 
 .sr-only {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -4,15 +4,30 @@
  */
 
 .heroBanner {
-  padding: 4rem 0;
+  padding: 5rem 0 4rem;
   text-align: center;
   position: relative;
   overflow: hidden;
 }
 
+.heroBanner :global(.hero__title) {
+  max-width: 18ch;
+  margin-left: auto;
+  margin-right: auto;
+  padding-inline: 5.56vw;
+}
+
+.heroBanner :global(.hero__subtitle) {
+  margin-top: 1.25rem;
+}
+
 @media screen and (max-width: 996px) {
   .heroBanner {
-    padding: 2rem;
+    padding: 3rem 1.25rem 2.5rem;
+  }
+
+  .heroBanner :global(.hero__title) {
+    padding-inline: 0;
   }
 }
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -15,7 +15,7 @@ function HomepageHeader() {
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <Heading as="h1" className="hero__title">
+        <Heading as="h1" className="hero__title aem-big-title">
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies sitewide typography inspired by [Eightshift’s blog](https://eightshift.com/blog/), using **Helvetica Neue** instead of licensed Neue Haas Grotesk.

### Changes
- **Font stack:** `"Helvetica Neue", Helvetica, Arial, sans-serif` for body, headings, nav, and buttons
- **Display / hero title:** Eightshift-style fluid clamp (`~3.7rem` → `~7.9rem`), `font-weight: 700`, `letter-spacing: -0.0208em`, `line-height: 0.98`
- **Doc headings:** responsive clamp sizes, bold weight, tight tracking
- **Body:** 17px base, ~1.55 line-height
- Homepage hero spacing tweaked so the brand title reads as the primary display mark

### Files
- `website/src/css/custom.css`
- `website/src/pages/index.tsx` / `index.module.css`
- `website/src/components/MetricsStrip/styles.module.css`

### Notes
Helvetica Neue is a system font (best on macOS). Windows/Linux fall back to Helvetica/Arial. No webfont download required.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81aa43e2-2553-4540-81be-cd8a1dec184a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81aa43e2-2553-4540-81be-cd8a1dec184a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

