### PR TITLE
Add Klinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Explore filters: [esp](https://llazyemail.github.io/awesome-email-marketing/expl
 * [Froged](https://froged.com) - Optimize your Customer Experience with One Powerful Product
 * [Jilt](https://jilt.com) - eCommerce email marketing for WooCommerce, Shopify, and EDD Jilt
 * [Keap](https://keap.com) - the all-in-one sales and marketing automation platform designed to help you grow
+* [Klinky](https://klinky.io) - A/B testing link shortener: split one campaign link between two destinations and measure which one wins
 * [Omnisend](https://omnisend.com) - is an omnichannel marketing automation platform for growth-focused ecommerce businesses
 * [Palabra](https://palabra.io) - Automate your product-led growth
 * [SalesLabel](https://sales-label.com) - White-label outbound email automation for B2B agencies. Multi-channel email + LinkedIn workflows with unlimited sending inboxes and built-in deliverability.


### PR DESCRIPTION
Adds [Klinky](https://klinky.io) to the Growth & Automation Tools section, in alphabetical order.

Why it fits an email marketing list: email marketers put links in campaigns, and Klinky lets you A/B test where a campaign link sends people — one short link splits traffic between two destinations at weights you choose (e.g., current landing page vs. a new offer page), with real-time click analytics to compare results. Useful for testing campaign destinations without changing the link after the email has been sent. Free tier available.
