### PR TITLE
docs(readme): add Cold Email Italy Observatory to Data Driven Email Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Docs: [`website/docs/tools/automation-platforms.md`](./website/docs/tools/automa
 - [Data-Driven Email Marketing Strategies](https://emailmastery.org/data-driven-email-marketing-strategies/) 
 - [Better Emails With Data-Driven Marketing: A Beginner’s Guide](https://www.tye.io/en/blog/data-driven-email-marketing/) 
 - [How to Get Started with Data-Driven Email Marketing](https://clevertap.com/blog/get-started-with-data-driven-email-marketing/) 
+- [Cold Email Italy Observatory](https://github.com/arnold222a/osservatorio-cold-email-italia) - Open dataset of 723 Italian B2B cold email campaigns (3.7M emails) with reply-rate benchmarks by industry, CC BY 4.0
 
 Order is :
 


### PR DESCRIPTION
## What this adds

One entry in the **Data Driven Email Marketing** section: the Cold Email Italy Observatory, an open dataset of 723 Italian B2B cold email campaigns (3,685,033 emails sent, 2024-2026) with reply-rate and bounce-rate benchmarks by industry, published as CSV/JSON with a documented methodology.

## Why it fits this section

The section collects data-driven email marketing resources; the existing entries are articles about the approach, while this adds primary data that can actually be used for benchmarking campaign performance.

## License and availability

- License: CC BY 4.0
- DOI: [10.5281/zenodo.21541001](https://doi.org/10.5281/zenodo.21541001)
- Mirrors: Zenodo, Hugging Face, Kaggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)