### PR TITLE
Add Email Subject Line Tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Explore filters: [esp](https://llazyemail.github.io/awesome-email-marketing/expl
 
 ### Deliverability & Testing Tools
 
+* [Email Subject Line Tester](https://alltoolsverse.com/tools/email-subject-line-tester/) - Analyzes subject-line length, spam triggers, capitalization, punctuation, and mobile and desktop inbox previews.
 * [Mailtrap](https://mailtrap.io) - is a testing tool and is not designed to deliver emails to real addresses
 * [Mailwarm](https://mailwarm.com) - Don't land in spam anymore
 * [Sendgrid](https://sendgrid.com) - Email delivery service


### PR DESCRIPTION
## Summary

- Adds Email Subject Line Tester to Deliverability & Testing Tools.
- Keeps the change to one alphabetized README entry.

## Why it fits

- The tool analyzes subject-line length, spam-trigger heuristics, capitalization, punctuation, and mobile and desktop inbox previews.
- It is free, works in the browser, and does not require sign-up.
- A live test with a 41-character subject returned the expected character and word counts, effectiveness and spam-risk scores, engagement rating, and mobile truncation preview.
- I checked the repository and pull request history for this resource and found no existing All Tools Verse entry or duplicate submission.

## Disclosure

I build and maintain All Tools Verse. I used OpenAI Codex to help research repository fit, verify the live tool, and prepare this one-line change. I reviewed the final wording and diff.